### PR TITLE
Removed gulp-sonar defaulting to js if language isn't set in options.…

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (options) {
             process;
 
         options = (typeof options === 'object') ? options : { sonar: {} };
-        options.sonar.language = options.sonar.language || 'js';
+        options.sonar.language = options.sonar.language;
         options.sonar.sourceEncoding = options.sonar.sourceEncoding || 'UTF-8';
         options.sonar.host = options.sonar.host || { url: 'http://localhost:9000' };
         options_exec = options.sonar.exec;


### PR DESCRIPTION
… This is to allow multi language support by leaving sonar.language undefined http://docs.sonarqube.org/display/SONAR/Analysis+Parameters