### PR TITLE
Add missing properties dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "gulp-util": "3.0.1",
     "lodash": "4.12.0",
-    "through2": "0.6.3"
+    "through2": "0.6.3",
+    "properties": "1.2.1"
   }
 }


### PR DESCRIPTION
The `properties` dependency referenced on line 10 of `index.js` was not included in the `package.json` file which resulted in an error running the plugin.
