### PR TITLE
added support for windows folders that contain spaces.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (options) {
     SONAR_SCANNER_HOME = path.join(__dirname, format('/sonar-scanner-%s', SONAR_VERSION));
     SONAR_SCANNER_PROPERTIES = path.join(__dirname, format('/sonar-scanner-%s', SONAR_VERSION), 'conf', 'sonar-scanner.properties');
     SONAR_SCANNER_JAR = format('/lib/sonar-scanner-cli-%s.jar', SONAR_VERSION);
-    SONAR_SCANNER_COMMAND = 'java -jar ' + path.join(SONAR_SCANNER_HOME, SONAR_SCANNER_JAR) + ' -X -Drunner.home=' + SONAR_SCANNER_HOME + ' -Dproject.settings=' + SONAR_SCANNER_PROPERTIES;
+    SONAR_SCANNER_COMMAND = 'java -jar "' + path.join(SONAR_SCANNER_HOME, SONAR_SCANNER_JAR) + '" -X -Drunner.home="' + SONAR_SCANNER_HOME + '" -Dproject.settings="' + SONAR_SCANNER_PROPERTIES + '"';
 
     write = function (file, enc, cb) {
         // do nothing with source ... not needed


### PR DESCRIPTION
When running the gulp-sonar task with a path that contains spaces on a windows machine the task will fail with a 'throw new pluginerror.....', I then removed the spaces and the task would run without issue.