### PR TITLE
remove jdbc config and add sonar credentials to config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,8 @@ gulp.task('sonar', function () {
             host: {
                 url: 'http://localhost:9000'
             },
-            jdbc: {
-                url: 'jdbc:mysql://localhost:3306/sonar',
-                username: 'sonar',
-                password: 'sonar'
-            },
+            login: 'admin',
+            password: 'admin',
             projectKey: 'sonar:my-project:1.0.0',
             projectName: 'My Project',
             projectVersion: '1.0.0',


### PR DESCRIPTION
From my experience the jdbc section in the config is not necessary. Instead we should document how to provide the credentials for SonarQube which are needed as soon as you activate the user authentication in SonarQube.

How I came to this conclusion:
I setup SonarQube (user authentication deactivated) with a MySQL database. Then I scanned my project with the gulp-sonar task using the config from the example but without the jdbc section and it was working totally fine for me.

Later I activated the user authentication in SonarQube and run the gulp task again and (as expected) it failed:

> Caused by: Not authorized. Analyzing this project requires to be authenticated. Please provide the values of the properties sonar.login and sonar.password.

I added the properties login and password to the config object (like described in my PR) and then it was working.
